### PR TITLE
Partially fix Japanse card serch (#2)

### DIFF
--- a/src/wikia.ts
+++ b/src/wikia.ts
@@ -37,6 +37,12 @@ export async function _fetchImageUrl(title: string): Promise<string | null> {
   return null;
 }
 
+const excludeTitlePatterns = [
+  /^List of /,
+  /^(Chapter|Episode) Card Galleries:/,
+  / \((?!card).*\)$/
+];
+
 export async function _searchTitle(name: string): Promise<string | null> {
   const url = endpoints.search + encodeURIComponent(name);
   const response = await fetch(url);
@@ -47,7 +53,10 @@ export async function _searchTitle(name: string): Promise<string | null> {
     const $els = html.querySelectorAll('.result h1 .result-link');
     for (const $el of $els) {
       const title = $el.textContent;
-      if (title && !title.match(/^List of /)) {
+      if (
+        title &&
+        excludeTitlePatterns.every(pattern => !title.match(pattern))
+      ) {
         return title;
       }
     }


### PR DESCRIPTION
FIx:
- [《勝利の方程式》](http://yugioh-wiki.net/index.php?%A1%D4%BE%A1%CD%F8%A4%CE%CA%FD%C4%F8%BC%B0%A1%D5)
- [《ＤＤＤ超視王ゼロ・マクスウェル》](http://yugioh-wiki.net/index.php?%A1%D4%A3%C4%A3%C4%A3%C4%C4%B6%BB%EB%B2%A6%A5%BC%A5%ED%A1%A6%A5%DE%A5%AF%A5%B9%A5%A6%A5%A7%A5%EB%A1%D5)
- [ 《超天新龍オッドアイズ・レボリューション・ドラゴン》](http://yugioh-wiki.net/index.php?%A1%D4%C4%B6%C5%B7%BF%B7%CE%B6%A5%AA%A5%C3%A5%C9%A5%A2%A5%A4%A5%BA%A1%A6%A5%EC%A5%DC%A5%EA%A5%E5%A1%BC%A5%B7%A5%E7%A5%F3%A1%A6%A5%C9%A5%E9%A5%B4%A5%F3%A1%D5)
- [《ＥＭカード・ガードナー》](http://yugioh-wiki.net/index.php?%A1%D4%A3%C5%A3%CD%A5%AB%A1%BC%A5%C9%A1%A6%A5%AC%A1%BC%A5%C9%A5%CA%A1%BC%A1%D5)
- [《白闘気双頭神龍》](http://yugioh-wiki.net/index.php?%A1%D4%C7%F2%C6%AE%B5%A4%C1%D0%C6%AC%BF%C0%CE%B6%A1%D5)
